### PR TITLE
Fix onModalClose callback when another modal opens

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -56,6 +56,10 @@ export const connectCallModal = function(WrappedComponent) {
     }
 
     show = async (property) => {
+      // If a modal is already open, run the onModalClose callback
+      if (_.isFunction(this.state.content)) {
+        this.state.onModalClose();
+      }
       return new Promise((resolve, reject) => {
         if(!_.isFunction(property.renderFunction)) {
           return reject(new Error('Require property: renderFunction'));


### PR DESCRIPTION
Currently, if you open a second modal it replaces the first, and the onModalClose callback will never run for the first modal. This runs the callback when the second modal opens.