### PR TITLE
Fix inner's modal animation delay will result to browser hang

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -19,8 +19,17 @@ const styles = StyleSheet.create({
 });
 const supportedOrientations = ['portrait', 'landscape'];
 
-const api = {}
+const api = {};
 export const CallModal = api;
+const DEFAULT_MODAL_CLOSE_ANIM_DELAY_MS = 250;
+
+async function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
 export const connectCallModal = function(WrappedComponent) {
   return class extends Component {
     state = {
@@ -30,7 +39,7 @@ export const connectCallModal = function(WrappedComponent) {
       content: () => null,
       closeWhenPressBackground: false,
       backgroundColor: 'rgba(0, 0, 0, 0.3)',
-    }
+    };
     componentDidMount() {
       api.show = this.show;
     }
@@ -38,30 +47,39 @@ export const connectCallModal = function(WrappedComponent) {
       if (this.state.closeWhenPressBackground) {
         this.handleCloseModal();
       }
-    }
+    };
 
     handleContentPress = () => {
       return false;
-    }
+    };
     handleCloseModal = () => {
       this.state.onModalClose();
       this.setState({
         animationType: 'slide',
         visible: false,
+        isAnimating: true,
         onModalClose: () => {},
         content: () => null,
         closeWhenPressBackground: false,
         backgroundColor: 'rgba(0, 0, 0, 0.3)',
       });
-    }
+      setTimeout(() => {
+        this.setState({
+          isAnimating: false,
+        });
+      }, DEFAULT_MODAL_CLOSE_ANIM_DELAY_MS);
+    };
 
-    show = async (property) => {
+    show = async property => {
       // If a modal is already open, run the onModalClose callback
+      if (this.state.isAnimating) {
+        await wait(DEFAULT_MODAL_CLOSE_ANIM_DELAY_MS);
+      }
       if (_.isFunction(this.state.content)) {
         this.state.onModalClose();
       }
       return new Promise((resolve, reject) => {
-        if(!_.isFunction(property.renderFunction)) {
+        if (!_.isFunction(property.renderFunction)) {
           return reject(new Error('Require property: renderFunction'));
         }
         this.setState({
@@ -71,8 +89,8 @@ export const connectCallModal = function(WrappedComponent) {
           backgroundColor: property.backgroundColor || 'rgba(0, 0, 0, 0.3)',
           closeWhenPressBackground: property.closeWhenPressBackground,
         });
-      }) 
-    }
+      });
+    };
 
     render() {
       const Content = this.state.content;
@@ -89,9 +107,12 @@ export const connectCallModal = function(WrappedComponent) {
           >
             <TouchableWithoutFeedback onPress={this.handleBackgroundPress}>
               <View
-                style={[styles.modalBackground, {
-                  backgroundColor: this.state.backgroundColor,
-                }]}
+                style={[
+                  styles.modalBackground,
+                  {
+                    backgroundColor: this.state.backgroundColor,
+                  },
+                ]}
               >
                 <TouchableWithoutFeedback onPress={this.handleContentPress}>
                   <Content requestCloseModal={this.handleCloseModal} />
@@ -102,5 +123,5 @@ export const connectCallModal = function(WrappedComponent) {
         </View>
       );
     }
-  }
-}
+  };
+};


### PR DESCRIPTION
## Problem

- Click ```Show Select Prompt Modal Twice``` in storybook will cause browser hang and cannot click button again 
https://mybigday.github.io/mybigday-ui-kit/?selectedKind=CallModal&selectedStory=Show%20Select%20Prompt%20Twice&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel
