### PR TITLE
make checkbox prompt can be scrollable

### DIFF
--- a/util.js
+++ b/util.js
@@ -8,6 +8,7 @@ import {
   Dimensions,
   TouchableWithoutFeedback,
   StyleSheet,
+  ScrollView,
 } from 'react-native';
 
 const MODAL_WIDTH = Dimensions.get('window').width / 2;
@@ -229,7 +230,7 @@ class CheckBoxPrompt extends Component {
   render() {
     const Item = defaultItemRender;
     return (
-      <View>
+      <ScrollView contentContainerStyle={{maxHeight: MODAL_HEIGHT}}>
         {
           _.map(this.state.selectionList, ({ key, value, selected }, index) => (
             <Item
@@ -274,7 +275,7 @@ class CheckBoxPrompt extends Component {
             />
           ))
         }
-      </View>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
because the total of item's height may exceed window's height and also make button (ok/cancel) invisible.

<img width="648" alt="2018-01-29 10 52 39" src="https://user-images.githubusercontent.com/5291552/35516612-28364918-0547-11e8-81c4-62be5d7c4c39.png">
